### PR TITLE
allow grd_rct for setting default grid

### DIFF
--- a/R/default_grid.R
+++ b/R/default_grid.R
@@ -61,6 +61,13 @@ gdalio_local_grid <- function(x = 147, y = -42, buffer = 25e5, family = "laea", 
     crs <- d[[1]]$refsys[["wkt"]]
     x <- list(extent = ex, dimension = dimension, projection = crs)
   }
+  if (inherits(x, "wk_grd_rct")) {
+    rct <- unclass(x$bbox[1])
+    ex <- c(rct$xmin, rct$xmax, rct$ymin, rct$ymax)
+    crs <- attr(rct, "crs")
+    dimension <- dim(x$data)[1:2]
+    x <- list(extent = ex, dimension= dimension, projection = crs)
+  }
   has_extent <- is.numeric(x[["extent"]]) && length(x[["extent"]] == 4) && all(!is.na(x[["extent"]])) &&
     diff(x[["extent"]][1:2]) > 0 && diff(x[["extent"]][3:4]) > 0
   if (!has_extent) stop("invalid extent")


### PR DESCRIPTION
A PR to go with https://github.com/paleolimbot/wk/pull/95 dev-grid grid in wk

- add wk::grd_rct to supported grid specs for `gdalio_set_default_grid()` - maybe it will become the standard :)
- example code below to get  raster data or imagery data 

``` r
  #remotes::install_github("paleolimbot/wk@dev-grid")
  #remotes::install_github("hypertidy/gdalio@default-wk-grd_rct")
  
## a raster data source 
elevation.tiles.prod <- tempfile(fileext = ".xml")
writeLines('<GDAL_WMS>
  <Service name="TMS">
    <ServerUrl>https://s3.amazonaws.com/elevation-tiles-prod/geotiff/${z}/${x}/${y}.tif</ServerUrl>
  </Service>
  <DataWindow>
    <UpperLeftX>-20037508.34</UpperLeftX>
    <UpperLeftY>20037508.34</UpperLeftY>
    <LowerRightX>20037508.34</LowerRightX>
    <LowerRightY>-20037508.34</LowerRightY>
    <TileLevel>14</TileLevel>
    <TileCountX>1</TileCountX>
    <TileCountY>1</TileCountY>
    <YOrigin>top</YOrigin>
  </DataWindow>
  <Projection>EPSG:3857</Projection>
  <BlockSizeX>512</BlockSizeX>
  <BlockSizeY>512</BlockSizeY>
  <BandsCount>1</BandsCount>
  <DataType>Int16</DataType>
  <ZeroBlockHttpCodes>403,404</ZeroBlockHttpCodes>
  <DataValues>
    <NoData>-32768</NoData>
  </DataValues>
  <Cache/>
</GDAL_WMS>', elevation.tiles.prod)


## an image data source
eox.satellite <- "WMS:https://tiles.maps.eox.at/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&LAYERS=s2cloudless-2019&SRS=EPSG:4326&BBOX=-180.000000,-90.000000,180.000000,90.000000&FORMAT=image/png&TILESIZE=256&OVERVIEWCOUNT=17&MINRESOLUTION=0.0000053644180298&TILED=true"

## read via gdal into wk format
gdalio_grd_rct <- function(dsn, ...) {
  g <- gdalio::gdalio_get_default_grid()
  bbox <- wk::rct(
    g$extent[1L], g$extent[3L], g$extent[2L], g$extent[4L],
    crs = g$projection
  )
  dd <- gdalio_data(dsn, ...)
  ## we probably want a way to behave where 3,4 bands triggers IMAGE
  ## 1,2,5,n bands triggers DATA (first band)
  ## but, there's also greyscale etc. 
  if (length(dd) != 3L) {
    wk::grd_rct(t(matrix(dd[[1L]], g$dimension[1], g$dimension[2])), bbox)
  } else {
    wk::grd_rct(aperm(array(scales::rescale(do.call(c, dd)), c(g$dimension[1], g$dimension[2], 3L)), c(2, 1, 3)), bbox)
  }
}

rct1 <- wk::grd_rct(array(dim = c(360, 180, 0)), wk::rct(0, -90, 180, 30, crs = "OGC:CRS84"))
library(gdalio)
gdalio_set_default_grid(rct1)
r <- gdalio_grd_rct(elevation.tiles.prod)
plot(r, asp = "")
maps::map(add = T)
```

![](https://i.imgur.com/8r3cJFK.png)

``` r
w <- 5e6
h <- 5e6
rct2 <- wk::grd_rct(array(dim = c(512, 512, 0)), 
                    wk::rct(-w, -h, w, h, crs = "+proj=laea +lon_0=-63 +lat_0=44"))
gdalio_set_default_grid(rct2)
i <- gdalio_grd_rct(eox.satellite, bands = 1:3)
plot(i)
```

![](https://i.imgur.com/ZYBm502.png)

<sup>Created on 2021-08-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>
